### PR TITLE
Add force success to fake bucket UpdatePolicy method

### DIFF
--- a/pkg/client/fake/clientset.go
+++ b/pkg/client/fake/clientset.go
@@ -536,6 +536,10 @@ func (b *Buckets) UpdatePolicy(bucketName string, policy string, params map[stri
 			Code:        model.CodeInternalException,
 		}
 	}
+	_, ok = params["X-TEST/Buckets/UpdatePolicy/force-success"]
+	if ok {
+		return nil
+	}
 	found := false
 	if found {
 		b.policy[fmt.Sprintf("%s/%s", bucketName, params["namespace"])] = policy
@@ -722,7 +726,7 @@ var _ api.CRRInterface = (*CRR)(nil) // interface guard
 
 // PauseReplication implements the CRR API
 func (c *CRR) PauseReplication(destObjectScale string, destObjectStore string, params map[string]string) error {
-	//resume, _ := strconv.Atoi(params["pauseEndMills"])
+	// resume, _ := strconv.Atoi(params["pauseEndMills"])
 	resume, _ := strconv.ParseInt(params["pauseEndMills"], 10, 64)
 	c.Config.DestObjectScale = destObjectScale
 	c.Config.DestObjectStore = destObjectStore


### PR DESCRIPTION
<!--
# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
# 
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#      http://www.apache.org/licenses/LICENSE-2.0
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License
-->

# Description
Adds a way to force success on fake UpdatePolicy method through params field. This change will be useful when developers of other applications will need to write unit tests for their code and mock the behavior of goobjectscale.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Unit testing
- [ ] Integration testing

# Special Notes For Your Reviewer:
Please describe the parts of code reviewers should focus on.

# Additional documentation
- [ ] Enhancement proposals
- [ ] Usage documentation